### PR TITLE
update for stacks on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ The `$` represents a terminal command prompt; do not actually type in a `$`.
    `$ chmod +x standup.sh`
 
 5. Run the script with the optional arguments like :
-   `$ ./standup.sh "<insert Tor V3 pubkey>" "<insert node type>" "<insert ssh key>" "<insert ssh allowed IP's>" "<insert password for standup user>"`
+   `$ ./standup.sh "<insert Tor V3 pubkey>" "<insert node type>" "<insert ssh key>" "<insert ssh allowed IP's>" "<insert password for standup user>" <insert stacks miner private key>`
    -  It is highly recommended to add a `Tor V3 pubkey` for cookie authentication, so that even if your QR code is compromised an attacker would not be able to access your node.
    -  The `node type` is  "Mainnet", "Pruned Mainnet", "Testnet", "Pruned Testnet", or "Private Regtest", default is "Pruned Testnet".
    -  If you supply a `SSH_KEY` in the arguments, you will be able to easily access your node via SSH using your rsa pubkey.
    -  If you add `SYS_SSH_IP`, you host willl only accept SSH connections from those IPs.
    -  The `password` is used for a user called `standup`.
+   -  Stack miner private key is required.  For help generating a key see [Stacks Mining Docs](https://docs.blockstack.org/start-mining/mainnet#running-a-miner) or [stacks-gen](https://github.com/psq/stacks-gen) (recommended).
 
 ### Method Two: Install Using `LinodeStandup.sh`
 

--- a/Scripts/StandUp.sh
+++ b/Scripts/StandUp.sh
@@ -23,12 +23,12 @@
 # it allows you to easily access your node via SSH using your rsa pubkey, if you add
 # SYS_SSH_IP's your VPS will only accept SSH connections from those IP's.
 
-# StandUp.sh will create a user called standup, and assign the optional password you
+# StandUp.sh will create a user called ubuntu, and assign the optional password you
 # give it in the arguments.
 
 # StandUp.sh will create two logs in your root directory, to read them run:
-# $ cat standup.err
-# $ cat standup.log
+# $ cat ubuntu.err
+# $ cat ubuntu.log
 
 ####
 #0. Prerequisites
@@ -46,7 +46,7 @@
 # $ su - root
 
 # Then create the file for the script:
-# $ nano standup.sh
+# $ nano ubuntu.sh
 
 # Nano is a text editor that works in a terminal, you need to paste the entire contents
 # of this script into your terminal after running the above command,
@@ -56,26 +56,26 @@
 # return (just press enter to confirm you want to save and exit)
 
 # Then we need to make sure the script can be executable with:
-# $ chmod +x standup.sh
+# $ chmod +x ubuntu.sh
 
 # After that you can run the script with the optional arguments like so:
-# $ ./standup.sh "insert pubkey" "insert node type (see options below)" "insert ssh key" "insert ssh allowed IP's" "insert password for standup user"
+# $ ./ubuntu.sh "insert pubkey" "insert node type (see options below)" "insert ssh key" "insert ssh allowed IP's" "insert password for ubuntu user"
 
 ####
 # 1. Set Initial Variables from command line arguments
 ####
 
 # The arguments are read as per the below variables:
-# ./standup.sh "PUBKEY" "BTCTYPE" "SSH_KEY" "SYS_SSH_IP" "USERPASSWORD"
+# ./ubuntu.sh "PUBKEY" "BTCTYPE" "SSH_KEY" "SYS_SSH_IP" "USERPASSWORD"
 
 # If you want to omit an argument then input empty qoutes in its place for example:
-# ./standup "" "Mainnet" "" "" "aPasswordForTheUser"
+# ./ubuntu "" "Mainnet" "" "" "aPasswordForTheUser"
 
 # If you do not want to add any arguments and run everything as per the defaults simply run:
-# ./standup.sh
+# ./ubuntu.sh
 
-# For Tor V3 client authentication (optional), you can run standup.sh like:
-# ./standup.sh "descriptor:x25519:NWJNEFU487H2BI3JFNKJENFKJWI3"
+# For Tor V3 client authentication (optional), you can run ubuntu.sh like:
+# ./ubuntu.sh "descriptor:x25519:NWJNEFU487H2BI3JFNKJENFKJWI3"
 # and it will automatically add the pubkey to the authorized_clients directory, which
 # means the user is Tor authenticated before the node is even installed.
 PUBKEY=$1
@@ -83,13 +83,13 @@ PUBKEY=$1
 # Can be one of the following: "Mainnet", "Pruned Mainnet", "Testnet", "Pruned Testnet", or "Private Regtest", default is "Pruned Testnet"
 BTCTYPE=$2
 
-# Optional key for automated SSH logins to standup non-privileged account - if you do not want to add one add "" as an argument
+# Optional key for automated SSH logins to ubuntu non-privileged account - if you do not want to add one add "" as an argument
 SSH_KEY=$3
 
 # Optional comma separated list of IPs that can use SSH - if you do not want to add any add "" as an argument
 SYS_SSH_IP=$4
 
-# Optional password for the standup non-privileged account - if you do not want to add one add "" as an argument
+# Optional password for the ubuntu non-privileged account - if you do not want to add one add "" as an argument
 USERPASSWORD=$5
 
 # private key of miner address for stacks node
@@ -105,7 +105,7 @@ then
 fi
 
 # Output stdout and stderr to ~root files
-exec > >(tee -a /root/standup.log) 2> >(tee -a /root/standup.log /root/standup.err >&2)
+exec > >(tee -a /root/ubuntu.log) 2> >(tee -a /root/ubuntu.log /root/ubuntu.err >&2)
 
 ####
 # 2. Bring Debian Up To Date
@@ -145,21 +145,17 @@ ufw enable
 # 3. Set Up User
 ####
 
-# Create "standup" user with optional password and give them sudo capability
-/usr/sbin/useradd -m -p `perl -e 'printf("%s\n",crypt($ARGV[0],"password"))' "$USERPASSWORD"` -g sudo -s /bin/bash standup
-/usr/sbin/adduser standup sudo
-
-echo "$0 - Setup standup with sudo access."
+echo "$0 - Setup ubuntu with sudo access."
 
 # Setup SSH Key if the user added one as an argument
 if [ -n "$SSH_KEY" ]
 then
 
-   mkdir ~standup/.ssh
-   echo "$SSH_KEY" >> ~standup/.ssh/authorized_keys
-   chown -R standup ~standup/.ssh
+   mkdir ~ubuntu/.ssh
+   echo "$SSH_KEY" >> ~ubuntu/.ssh/authorized_keys
+   chown -R ubuntu ~ubuntu/.ssh
 
-   echo "$0 - Added .ssh key to standup."
+   echo "$0 - Added .ssh key to ubuntu."
 
 fi
 
@@ -209,17 +205,17 @@ sed -i -e 's/#ControlPort 9051/ControlPort 9051/g' /etc/tor/torrc
 sed -i -e 's/#CookieAuthentication 1/CookieAuthentication 1/g' /etc/tor/torrc
 sed -i -e 's/## address y:z./## address y:z.\
 \
-HiddenServiceDir \/var\/lib\/tor\/standup\/\
+HiddenServiceDir \/var\/lib\/tor\/ubuntu\/\
 HiddenServiceVersion 3\
 HiddenServicePort 1309 127.0.0.1:18332\
 HiddenServicePort 1309 127.0.0.1:18443\
 HiddenServicePort 1309 127.0.0.1:8332/g' /etc/tor/torrc
-mkdir /var/lib/tor/standup
-chown -R debian-tor:debian-tor /var/lib/tor/standup
-chmod 700 /var/lib/tor/standup
+mkdir /var/lib/tor/ubuntu
+chown -R debian-tor:debian-tor /var/lib/tor/ubuntu
+chmod 700 /var/lib/tor/ubuntu
 
-# Add standup to the tor group so that the tor authentication cookie can be read by bitcoind
-sudo usermod -a -G debian-tor standup
+# Add ubuntu to the tor group so that the tor authentication cookie can be read by bitcoind
+sudo usermod -a -G debian-tor ubuntu
 
 # Restart tor to create the HiddenServiceDir
 sudo systemctl restart tor.service
@@ -230,16 +226,16 @@ if ! [ "$PUBKEY" == "" ]
 then
 
   # create the directory manually incase tor.service did not restart quickly enough
-  mkdir /var/lib/tor/standup/authorized_clients
+  mkdir /var/lib/tor/ubuntu/authorized_clients
 
   # need to assign the owner
-  chown -R debian-tor:debian-tor /var/lib/tor/standup/authorized_clients
+  chown -R debian-tor:debian-tor /var/lib/tor/ubuntu/authorized_clients
 
   # Create the file for the pubkey
-  sudo touch /var/lib/tor/standup/authorized_clients/fullynoded.auth
+  sudo touch /var/lib/tor/ubuntu/authorized_clients/fullynoded.auth
 
   # Write the pubkey to the file
-  sudo echo "$PUBKEY" > /var/lib/tor/standup/authorized_clients/fullynoded.auth
+  sudo echo "$PUBKEY" > /var/lib/tor/ubuntu/authorized_clients/fullynoded.auth
 
   # Restart tor for authentication to take effect
   sudo systemctl restart tor.service
@@ -265,15 +261,15 @@ export BITCOIN="bitcoin-core-0.20.1"
 export BITCOINPLAIN=`echo $BITCOIN | sed 's/bitcoin-core/bitcoin/'`
 
 https://bitcoin.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-aarch64-linux-gnu.tar.gz
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz -O ~standup/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz
-sudo -u standup wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~standup/SHA256SUMS.asc
-sudo -u standup wget https://bitcoin.org/laanwj-releases.asc -O ~standup/laanwj-releases.asc
+sudo -u ubuntu wget https://bitcoincore.org/bin/$BITCOIN/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz -O ~ubuntu/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz
+sudo -u ubuntu wget https://bitcoincore.org/bin/$BITCOIN/SHA256SUMS.asc -O ~ubuntu/SHA256SUMS.asc
+sudo -u ubuntu wget https://bitcoin.org/laanwj-releases.asc -O ~ubuntu/laanwj-releases.asc
 
 # Verifying Bitcoin: Signature
 echo "$0 - Verifying Bitcoin."
 
-sudo -u standup /usr/bin/gpg --no-tty --import ~standup/laanwj-releases.asc
-export SHASIG=`sudo -u standup /usr/bin/gpg --no-tty --verify ~standup/SHA256SUMS.asc 2>&1 | grep "Good signature"`
+sudo -u ubuntu /usr/bin/gpg --no-tty --import ~ubuntu/laanwj-releases.asc
+export SHASIG=`sudo -u ubuntu /usr/bin/gpg --no-tty --verify ~ubuntu/SHA256SUMS.asc 2>&1 | grep "Good signature"`
 echo "SHASIG is $SHASIG"
 
 if [[ "$SHASIG" ]]
@@ -288,8 +284,8 @@ else
 fi
 
 # Verify Bitcoin: SHA
-export TARSHA256=`/usr/bin/sha256sum ~standup/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz | awk '{print $1}'`
-export EXPECTEDSHA256=`cat ~standup/SHA256SUMS.asc | grep $BITCOINPLAIN-aarch64-linux-gnu.tar.gz | awk '{print $1}'`
+export TARSHA256=`/usr/bin/sha256sum ~ubuntu/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz | awk '{print $1}'`
+export EXPECTEDSHA256=`cat ~ubuntu/SHA256SUMS.asc | grep $BITCOINPLAIN-aarch64-linux-gnu.tar.gz | awk '{print $1}'`
 
 if [ "$TARSHA256" == "$EXPECTEDSHA256" ]
 then
@@ -305,20 +301,20 @@ fi
 # Install Bitcoin
 echo "$0 - Installinging Bitcoin."
 
-sudo -u standup /bin/tar xzf ~standup/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz -C ~standup
-/usr/bin/install -m 0755 -o root -g root -t /usr/local/bin ~standup/$BITCOINPLAIN/bin/*
-/bin/rm -rf ~standup/$BITCOINPLAIN/
+sudo -u ubuntu /bin/tar xzf ~ubuntu/$BITCOINPLAIN-aarch64-linux-gnu.tar.gz -C ~ubuntu
+/usr/bin/install -m 0755 -o root -g root -t /usr/local/bin ~ubuntu/$BITCOINPLAIN/bin/*
+/bin/rm -rf ~ubuntu/$BITCOINPLAIN/
 
 # Start Up Bitcoin
 echo "$0 - Configuring Bitcoin."
 
-sudo -u standup /bin/mkdir ~standup/.bitcoin
+sudo -u ubuntu /bin/mkdir ~ubuntu/.bitcoin
 
 # The only variation between Mainnet and Testnet is that Testnet has the "testnet=1" variable
 # The only variation between Regular and Pruned is that Pruned has the "prune=550" variable, which is the smallest possible prune
 RPCPASSWORD=$(xxd -l 16 -p /dev/urandom)
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 server=1
 rpcuser=StandUp
 rpcpassword=$RPCPASSWORD
@@ -334,33 +330,33 @@ fi
 
 if [ "$BTCTYPE" == "Mainnet" ]; then
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 txindex=1
 EOF
 
 elif [ "$BTCTYPE" == "Pruned Mainnet" ]; then
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 prune=550
 EOF
 
 elif [ "$BTCTYPE" == "Testnet" ]; then
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 txindex=1
 testnet=1
 EOF
 
 elif [ "$BTCTYPE" == "Pruned Testnet" ]; then
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 prune=550
 testnet=1
 EOF
 
 elif [ "$BTCTYPE" == "Private Regtest" ]; then
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 regtest=1
 txindex=1
 EOF
@@ -372,7 +368,7 @@ else
 
 fi
 
-cat >> ~standup/.bitcoin/bitcoin.conf << EOF
+cat >> ~ubuntu/.bitcoin/bitcoin.conf << EOF
 [test]
 rpcbind=127.0.0.1
 rpcport=18332
@@ -384,8 +380,8 @@ rpcbind=127.0.0.1
 rpcport=18443
 EOF
 
-/bin/chown standup ~standup/.bitcoin/bitcoin.conf
-/bin/chmod 600 ~standup/.bitcoin/bitcoin.conf
+/bin/chown ubuntu ~ubuntu/.bitcoin/bitcoin.conf
+/bin/chmod 600 ~ubuntu/.bitcoin/bitcoin.conf
 
 # Setup bitcoind as a service that requires Tor
 echo "$0 - Setting up Bitcoin as a systemd service."
@@ -404,7 +400,7 @@ Description=Bitcoin daemon
 After=tor.service
 Requires=tor.service
 [Service]
-ExecStart=/usr/local/bin/bitcoind -conf=/home/standup/.bitcoin/bitcoin.conf
+ExecStart=/usr/local/bin/bitcoind -conf=/home/ubuntu/.bitcoin/bitcoin.conf
 # Process management
 ####################
 Type=simple
@@ -413,7 +409,7 @@ Restart=on-failure
 # Directory creation and permissions
 ####################################
 # Run as bitcoin:bitcoin
-User=standup
+User=ubuntu
 Group=sudo
 # /run/bitcoind
 RuntimeDirectory=bitcoind
@@ -441,18 +437,18 @@ sudo systemctl enable bitcoind.service
 sudo systemctl start bitcoind.service
 
 ####
-# 6. Install QR encoder and displayer, and show the btcstandup:// uri in plain text incase the QR Code does not display
+# 6. Install QR encoder and displayer, and show the btcubuntu:// uri in plain text incase the QR Code does not display
 ####
 
 # Get the Tor onion address for the QR code
-HS_HOSTNAME=$(sudo cat /var/lib/tor/standup/hostname)
+HS_HOSTNAME=$(sudo cat /var/lib/tor/ubuntu/hostname)
 
 # Create the QR string
-QR="btcstandup://StandUp:$RPCPASSWORD@$HS_HOSTNAME:1309/?label=StandUp.sh"
+QR="btcubuntu://StandUp:$RPCPASSWORD@$HS_HOSTNAME:1309/?label=StandUp.sh"
 
 # Display the uri text incase QR code does not work
 echo "$0 - **************************************************************************************************************"
-echo "$0 - This is your btcstandup:// uri to convert into a QR which can be scanned with FullyNoded to connect remotely:"
+echo "$0 - This is your btcubuntu:// uri to convert into a QR which can be scanned with FullyNoded to connect remotely:"
 echo $QR
 echo "$0 - **************************************************************************************************************"
 echo "$0 - Bitcoin is setup as a service and will automatically start if your VPS reboots and so is Tor"
@@ -467,23 +463,23 @@ echo "$0 - Downloading Stacks Node; this will also take a while!"
 # CURRENT RELEASE from github
 export STACKSNODE_URL=`curl -s https://api.github.com/repos/blockstack/stacks-blockchain/releases/latest | grep 'browser_' | grep 'arm64' | cut -d\" -f4`
 
-sudo -u standup wget $STACKSNODE_URL -O ~standup/stacks-blockchain-linux-arm64.zip
+sudo -u ubuntu wget $STACKSNODE_URL -O ~ubuntu/stacks-blockchain-linux-arm64.zip
 
 
 # Install Stacks Node
 echo "$0 - Installinging Stacks Node."
 
-sudo -u standup /bin/unzip ~standup/stacks-blockchain-linux-arm64.zip -d ~standup/stacks-blockchain
-sudo /usr/bin/install -m 0755 -o root -g root -t /usr/local/bin ~standup/stacks-blockchain/*
-sudo /bin/rm -rf ~standup/stacks-blockchain
-sudo /bin/rm ~standup/stacks-blockchain-linux-arm64.zip
+sudo -u ubuntu /bin/unzip ~ubuntu/stacks-blockchain-linux-arm64.zip -d ~ubuntu/stacks-blockchain
+sudo /usr/bin/install -m 0755 -o root -g root -t /usr/local/bin ~ubuntu/stacks-blockchain/*
+sudo /bin/rm -rf ~ubuntu/stacks-blockchain
+sudo /bin/rm ~ubuntu/stacks-blockchain-linux-arm64.zip
 
 # Configure Stacks Node
 echo "$0 - Configuring Stacks Node."
 
-sudo -u standup /bin/mkdir ~standup/.stacks
+sudo -u ubuntu /bin/mkdir ~ubuntu/.stacks
 
-sudo cat >> ~standup/.stacks/xenon.toml << EOF
+sudo cat >> ~ubuntu/.stacks/stacks.toml << EOF
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
@@ -491,18 +487,46 @@ seed = "$MINER_KEY"
 # local_peer_seed is optional
 #local_peer_seed = "replace-with-your-private-key"
 miner = true
+EOF
+
+if [ "$BTCTYPE" == "Mainnet" ]; then
+cat >> ~ubuntu/.stacks/stacks.toml << EOF
+bootstrap_node = "02da7a464ac770ae8337a343670778b93410f2f3fef6bea98dd1c3e9224459d36b@seed-0.mainnet.stacks.co:20444,02afeae522aab5f8c99a00ddf75fbcb4a641e052dd48836408d9cf437344b63516@seed-1.mainnet.stacks.co:20444,03652212ea76be0ed4cd83a25c06e57819993029a7b9999f7d63c36340b34a4e62@seed-2.mainnet.stacks.co:20444"
+EOF
+
+elif [ "$BTCTYPE" == "Testnet" ]; then
+cat >> ~ubuntu/.stacks/stacks.toml << EOF
 bootstrap_node = "047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@xenon.blockstack.org:20444"
-working_dir = "/home/standup/.stacks/xenon"
+EOF
+fi
+cat >> ~ubuntu/.stacks/stacks.toml << EOF
+working_dir = "/home/ubuntu/.stacks/xenon"
 burn_fee_cap = 20000
+wait_time_for_microblocks = 15000
 
 [burnchain]
 chain = "bitcoin"
-mode = "xenon"
 peer_host = "127.0.0.1"
-rpc_port = 18332
-peer_port = 18333
 username = "StandUp"
 password = "$RPCPASSWORD"
+satoshis_per_byte = 100
+burn_fee_cap = 20000
+
+EOF
+
+if [ "$BTCTYPE" == "Mainnet" ]; then
+cat >> ~ubuntu/.stacks/stacks.toml << EOF
+mode = "mainnet"
+rpc_port = 8332
+peer_port = 8333
+EOF
+
+elif [ "$BTCTYPE" == "Testnet" ]; then
+
+cat >> ~ubuntu/.stacks/stacks.toml << EOF
+mode = "xenon"
+rpc_port = 18332
+peer_port = 18333
 
 [[ustx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
@@ -520,16 +544,17 @@ amount = 10000000000000000
 address = "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
 amount = 10000000000000000
 EOF
+fi
 
-/bin/chown standup ~standup/.stacks/xenon.toml
-/bin/chmod 600 ~standup/.stacks/xenon.toml
+/bin/chown ubuntu ~ubuntu/.stacks/stacks.toml
+/bin/chmod 600 ~ubuntu/.stacks/stacks.toml
 
 # Setup stacks-node as a service 
 echo "$0 - Setting up Stacks Node as a systemd service."
 
 sudo cat > /etc/systemd/system/stacks-node.service << EOF
 [Unit]
-Description=Stacks Xenon Testnet
+Description=Stacks Miner
 After=network.target
 After=bitcoind.service
 Requires=bitcoind.service
@@ -537,11 +562,11 @@ Requires=bitcoind.service
 [Service]
 Type=simple
 Restart=always
-User=standup
+User=ubuntu
 Group=sudo
 Environment=BLOCKSTACK_DEBUG=1
 Environment=RUST_BACKTRACE=FULL
-ExecStart=/usr/local/bin/stacks-node start --config=/home/standup/.stacks/xenon.toml
+ExecStart=/usr/local/bin/stacks-node start --config=/home/ubuntu/.stacks/stacks.toml
 MemoryDenyWriteExecute=true
 PrivateDevices=true
 ProtectSystem=full


### PR DESCRIPTION
This update is focused on Ubuntu.  Changes:
* uses the default ubuntu user instead of creating a new "standup" user
* user the Bitcoin network option to determine and configure the stacks node setup for mainnet or testnet
* renames `xenon.toml` to `stacks.toml`
* updates the README to include the stacks private key command line option
